### PR TITLE
add report flag for printing key presses to console

### DIFF
--- a/src/main/java/com/whitemagicsoftware/kmcaster/KmCaster.java
+++ b/src/main/java/com/whitemagicsoftware/kmcaster/KmCaster.java
@@ -139,7 +139,7 @@ public final class KmCaster extends JFrame {
   }
 
   private void initKeyboardListener( final PropertyChangeListener listener ) {
-    final KeyboardListener keyboardListener = new KeyboardListener();
+    final KeyboardListener keyboardListener = new KeyboardListener(getUserSettings().isReport());
     addNativeKeyListener( keyboardListener );
     keyboardListener.addPropertyChangeListener( listener );
     keyboardListener.initModifiers();

--- a/src/main/java/com/whitemagicsoftware/kmcaster/Settings.java
+++ b/src/main/java/com/whitemagicsoftware/kmcaster/Settings.java
@@ -65,6 +65,16 @@ public final class Settings implements Callable<Integer> {
   private final KmCaster mKmCaster;
 
   /**
+   * Whether to report key presses to the console.
+   */
+  @CommandLine.Option(
+    names = {"-r", "--report"},
+    description = "Report key and mouse presses to the console",
+    defaultValue = "false"
+  )
+  private boolean mReport;
+
+  /**
    * Milliseconds to wait before releasing (clearing) a regular key.
    */
   @CommandLine.Option(
@@ -269,4 +279,9 @@ public final class Settings implements Callable<Integer> {
   public String getBackgroundColour() {
     return mBackgroundColour;
   }
+
+  public boolean isReport() {
+    return mReport;
+  }
+  
 }

--- a/src/main/java/com/whitemagicsoftware/kmcaster/listeners/KeyboardListener.java
+++ b/src/main/java/com/whitemagicsoftware/kmcaster/listeners/KeyboardListener.java
@@ -288,14 +288,17 @@ public final class KeyboardListener
   private final Map<HardwareSwitch, Boolean> mModifiers = new HashMap<>();
 
   private final Set<HandedSwitch> mHandedModifiers = new HashSet<>();
+  private boolean report;
 
   /**
    * Creates a keyboard listener that publishes events when keys are either
    * pressed or released. The constructor initializes all modifier keys to
    * the released state because the native keyboard hook API does not offer
    * a way to query what keys are currently pressed.
+ * @param b
    */
-  public KeyboardListener() {
+  public KeyboardListener(boolean report) {
+    this.report = report;
     for( final var key : modifierSwitches() ) {
       mModifiers.put( key, FALSE );
     }
@@ -308,6 +311,8 @@ public final class KeyboardListener
    */
   @Override
   public void nativeKeyTyped( final NativeKeyEvent e ) {
+    report(e);
+
     if( isRegular( e ) ) {
       String key = getDisplayText( e.getKeyChar() );
 
@@ -322,6 +327,8 @@ public final class KeyboardListener
 
   @Override
   public void nativeKeyPressed( final NativeKeyEvent e ) {
+    report(e);
+
     dispatchModifiers( e, TRUE );
 
     if( e.isActionKey() && isRegular( e ) && IS_OS_WINDOWS ) {
@@ -331,6 +338,8 @@ public final class KeyboardListener
 
   @Override
   public void nativeKeyReleased( final NativeKeyEvent e ) {
+    report(e);
+
     dispatchModifiers( e, FALSE );
 
     if( e.isActionKey() && isRegular( e ) && IS_OS_WINDOWS ) {
@@ -449,5 +458,21 @@ public final class KeyboardListener
 
   private String getDisplayText( final char keyChar ) {
     return CHAR_CODES.getOrDefault( keyChar, String.valueOf( keyChar ) );
+  }
+
+  int last=-1;
+
+  /**
+   * prints the key event to the console, putting a newline on each new key
+   * for easier visual separation.
+   */
+  private void report(NativeKeyEvent e) {
+    if (report) {
+      if(e.getRawCode() != last) {
+        System.out.println();
+      }
+      System.out.println(e.paramString());
+      last = e.getRawCode();
+    }
   }
 }


### PR DESCRIPTION
making it easier for users to help report misreported keys.

chose '--report/-r' as both 'd' and 'v' flags already taken.